### PR TITLE
Indent between parentheses.

### DIFF
--- a/settings/setting-lua.json
+++ b/settings/setting-lua.json
@@ -2,8 +2,8 @@
   ".source.lua": {
     "editor": {
       "commentStart": "-- ",
-      "decreaseIndentPattern": "(^\\s*\\b(elsei|elseif|else|end|until)\\b.*$|^((?!\\{).)*\\}\\;?.*$)",
-      "increaseIndentPattern": "(^\\s*\\b((local[\\s\\w=]+)?function|repeat|else|elseif|if|while)\\b((?!\\bend\\b).)*$|^.*\\b(do|then)\\b((?!\\bend\\b).)*$|^.*\\{((?!\\}).)*$)"
+      "decreaseIndentPattern": "(^\\s*\\b(elsei|elseif|else|end|until)\\b.*$|^((?!\\{).)*\\}\\;?.*$|^((?!\\().)*\\)\\;?.*$)",
+      "increaseIndentPattern": "(^\\s*\\b((local[\\s\\w=]+)?function|repeat|else|elseif|if|while)\\b((?!\\bend\\b).)*$|^.*\\b(do|then)\\b((?!\\bend\\b).)*$|^.*\\{((?!\\}).)*$|^.*\\(((?!\\)).)*$)"
     }
   }
 }


### PR DESCRIPTION
Adds the same indentation rules that are already there for curly brackets to parentheses. So typing `func(↵param1,↵param2↵)` results in
```lua
func(
    param1,
    param2
)
```
instead of
```lua
func(
param1,
param2
)
```